### PR TITLE
Look for walls if distance is > 1

### DIFF
--- a/CapMan.Tests/Board_should.cs
+++ b/CapMan.Tests/Board_should.cs
@@ -33,13 +33,18 @@ public class Board_should
     [Theory]
     //                             start     d    end
     [InlineData(Direction.Right, 2.5, 1.0, 1.0, 3.0, 1.0)]
-    [InlineData(Direction.Left, 1.5, 1.0, 1.0, 1.0, 1.0)]
-    [InlineData(Direction.Up, 1.0, 1.5, 1.0, 1.0, 1.0)]
-    [InlineData(Direction.Down, 1.0, 2.5, 1.0, 1.0, 3.0)]
+    [InlineData(Direction.Left,  1.5, 1.0, 1.0, 1.0, 1.0)]
+    [InlineData(Direction.Up,    1.0, 1.5, 1.0, 1.0, 1.0)]
+    [InlineData(Direction.Down,  1.0, 2.5, 1.0, 1.0, 3.0)]
     [InlineData(Direction.Right, 2.9, 1.0, 0.2, 3.0, 1.0)]
-    [InlineData(Direction.Left, 1.1, 1.0, 0.2, 1.0, 1.0)]
-    [InlineData(Direction.Up, 1.0, 1.1, 0.2, 1.0, 1.0)]
-    [InlineData(Direction.Down, 1.0, 2.9, 0.2, 1.0, 3.0)]
+    [InlineData(Direction.Left,  1.1, 1.0, 0.2, 1.0, 1.0)]
+    [InlineData(Direction.Up,    1.0, 1.1, 0.2, 1.0, 1.0)]
+    [InlineData(Direction.Down,  1.0, 2.9, 0.2, 1.0, 3.0)]
+    // Move a longer distance with a wall in the way
+    [InlineData(Direction.Right, 2.0, 2.0, 5.0, 3.0, 2.0)]
+    [InlineData(Direction.Left,  2.4, 2.4, 5.0, 1.0, 2.0)]
+    [InlineData(Direction.Up,    2.6, 2.6, 5.0, 2.0, 1.0)]
+    [InlineData(Direction.Down,  2.0, 2.0, 5.0, 2.0, 3.0)]
     public void does_not_allow_move_when_space_is_wall(Direction direction, double startX, double startY, double distance, double endX, double endY)
     {
 

--- a/CapMan/Board/Board.cs
+++ b/CapMan/Board/Board.cs
@@ -119,6 +119,26 @@ public static class BoardExtensions
         Position next = position.Move(moving, distance);
         Tile step = next.NextTile(moving);
 
+        if (distance > 1)
+        {
+            Tile startTile = position.CurrentTile(moving);
+            int deltaX = int.Sign(step.X - startTile.X);
+            int deltaY = int.Sign(step.Y - startTile.Y);
+            int noOfSteps = int.Max(int.Abs(startTile.X - step.X), int.Abs(startTile.Y - step.Y)) + 1;
+
+            Tile prevTile = startTile;
+            for (int i = 1; i <= noOfSteps; i++)
+            {
+                Tile tile = startTile with { X = startTile.X + (i * deltaX), Y = startTile.Y + (i * deltaY) };
+                if (board.IsWall(tile))
+                {
+                    step = tile;
+                    next = prevTile.ToPosition();
+                    break;
+                }
+            }
+        }
+
         // If there is no wall, return move
         if (!board.IsWall(step)) { return next; }
 

--- a/CapMan/Board/Board.cs
+++ b/CapMan/Board/Board.cs
@@ -124,7 +124,7 @@ public static class BoardExtensions
             Tile startTile = position.CurrentTile(moving);
             int deltaX = int.Sign(step.X - startTile.X);
             int deltaY = int.Sign(step.Y - startTile.Y);
-            int noOfSteps = int.Max(int.Abs(startTile.X - step.X), int.Abs(startTile.Y - step.Y)) + 1;
+            int noOfSteps = int.Max(int.Abs(startTile.X - step.X), int.Abs(startTile.Y - step.Y));
 
             Tile prevTile = startTile;
             for (int i = 1; i <= noOfSteps; i++)


### PR DESCRIPTION
This fixes #7 and stops CapMan appearing inside walled off areas or wrapping around, but it might be better to pause the game when this occurs rather than let time play out.