### PR TITLE
Fixes the issue "Limit Game Speed changes in debug mode"

### DIFF
--- a/CapMan.Raylib/GameConstants.cs
+++ b/CapMan.Raylib/GameConstants.cs
@@ -1,0 +1,9 @@
+namespace CapMan.Raylib;
+
+public static class GameConstants
+{
+    /// <summary>
+    /// Maximum Game Speed configurable by debug keybinds
+    /// </summary>
+    public const int DebugMaxGameSpeed = 25;
+}

--- a/CapMan.Raylib/Program.cs
+++ b/CapMan.Raylib/Program.cs
@@ -28,11 +28,6 @@ bool debugText = false;
 bool drawLines = false;
 bool paused = false;
 
-/// <summary>
-/// Maximum Game Speed configurable by debug keybinds
-/// </summary>
-const int DebugMaxGameSpeed = 25;
-
 Console.WriteLine(Environment.CurrentDirectory);
 
 Game game = InitGame();
@@ -224,7 +219,7 @@ void HandleInput()
     }
     if (Raylib.IsKeyPressed(KeyboardKey.Zero))
     {
-        game.Player.Speed = Math.Min(++game.Player.Speed, DebugMaxGameSpeed);
+        game.Player.Speed = Math.Min(++game.Player.Speed, GameConstants.DebugMaxGameSpeed);
     }
     if (Raylib.IsKeyPressed(KeyboardKey.Nine))
     {

--- a/CapMan.Raylib/Program.cs
+++ b/CapMan.Raylib/Program.cs
@@ -28,6 +28,11 @@ bool debugText = false;
 bool drawLines = false;
 bool paused = false;
 
+/// <summary>
+/// Maximum Game Speed configurable by debug keybinds
+/// </summary>
+const int DebugMaxGameSpeed = 25;
+
 Console.WriteLine(Environment.CurrentDirectory);
 
 Game game = InitGame();
@@ -219,11 +224,11 @@ void HandleInput()
     }
     if (Raylib.IsKeyPressed(KeyboardKey.Zero))
     {
-        game.Player.Speed++;
+        game.Player.Speed = Math.Min(++game.Player.Speed, DebugMaxGameSpeed);
     }
     if (Raylib.IsKeyPressed(KeyboardKey.Nine))
     {
-        game.Player.Speed--;
+        game.Player.Speed = Math.Max(--game.Player.Speed, 0);
     }
     if (Raylib.IsKeyPressed(KeyboardKey.G))
     {


### PR DESCRIPTION
Fix issue #25 "Limit Game Speed changes in debug mode"

Changes made:

1. Added a new constant, `DebugMaxGameSpeed`, which defines the maximum allowed game speed when using debug keybinds.
2. Changed the handling of the "0" and "9" keys in the `HandleInput` method to ensure that the player's speed is limited to values between 0 and the specified `DebugMaxGameSpeed`