### PR TITLE
feat: Implement slow enemy movement in tunnels.

### DIFF
--- a/CapMan.Raylib/BoardRenderer.cs
+++ b/CapMan.Raylib/BoardRenderer.cs
@@ -9,7 +9,7 @@ public class BoardRenderer
 
     public void Render(Board board, int left, int top)
     {
-        foreach ((Tile pos, Element el) in board.Elements)
+        foreach ((Tile pos, Element el) in board.Elements.Where(kvp => kvp.Value.IsRenderable()))
         {
             Raylib.DrawTexture(Textures[el], left + pos.X * CellSize, top + pos.Y * CellSize, Color.White);
         }
@@ -20,7 +20,7 @@ public class BoardRenderer
         if (s_textures == null)
         {
             s_textures = new();
-            foreach (Element element in Enum.GetValues<Element>().Where(el => el is not Element.Corner))
+            foreach (Element element in Enum.GetValues<Element>().Where(el => el.IsRenderable()))
             {
                 Image image = Raylib.LoadImage(AssetPath(element));
                 Texture2D texture = Raylib.LoadTextureFromImage(image);

--- a/CapMan.Raylib/ElementExtensions.cs
+++ b/CapMan.Raylib/ElementExtensions.cs
@@ -1,0 +1,11 @@
+namespace CapMan.Raylib;
+
+using static Element;
+
+public static class ElementExtensions
+{
+    public static bool IsRenderable(this Element element)
+    {
+        return element is Dot or PowerPill or Vertical or Horizontal or TopLeft or TopRight or BottomLeft or BottomRight or Door;
+    }
+}

--- a/CapMan/Actors/EnemyActor.cs
+++ b/CapMan/Actors/EnemyActor.cs
@@ -3,18 +3,30 @@ namespace CapMan;
 public class EnemyActor(Position position, double speed, Direction direction) : Actor(position, speed, direction)
 {
     public Position StartPosition { get; } = position;
+    public double BaseSpeed { get; set; } = speed;
     public EnemyState State { get; set; } = EnemyState.Searching;
     public IEnemyBehaviour Behaviour { get; set; } = new TargetTileBehaviour(new Tile(1, 1));
     public Tile? LastTarget { get; set; }
     public bool IgnoreDoors { get; set; } = false;
     public override void Update(IGame game, double deltaTime)
     {
+        SetSpeed(game);
         if (IgnoreDoors)
         {
             game = new DelegateBoardGame(game, game.Board.WithoutDoors());
         }
         NextDirection = Behaviour.GetNextDirection(game, deltaTime, this);
+
         base.Update(game, deltaTime);
+    }
+
+    private void SetSpeed(IGame game)
+    {
+        this.Speed = BaseSpeed;
+        if (game.Board.IsSlowTile(this.Tile))
+        {
+            this.Speed *= 0.75;
+        }
     }
 
     public void Reset()

--- a/CapMan/Board/Board.cs
+++ b/CapMan/Board/Board.cs
@@ -78,6 +78,7 @@ public class Board
     public bool IsDot(Tile position) => TryGetElement(position, out Element element) && element.IsDot();
     public bool IsPowerPill(Tile position) => TryGetElement(position, out Element element) && element.IsPowerPill();
     public bool IsWall(Tile position) => TryGetElement(position, out Element element) && element.IsWall();
+    public bool IsSlowTile(Tile position) => TryGetElement(position, out Element element) && element.IsSlowTile();
     public bool Contains(Tile position) => position.Y >= 0 && position.Y < Height && position.X >= 0 && position.X < Width;
 
     public static readonly string StandardBoard = """
@@ -95,7 +96,7 @@ public class Board
              │.││          ││.│     
              │.││ ╭──==──╮ ││.│     
         ─────╯.╰╯ │      │ ╰╯.╰─────
-              .   │      │   .      
+        ::::: .   │      │   . :::::
         ─────╮.╭╮ │      │ ╭╮.╭─────
              │.││ ╰──────╯ ││.│     
              │.││          ││.│     

--- a/CapMan/Element.cs
+++ b/CapMan/Element.cs
@@ -12,6 +12,7 @@ public enum Element : ushort
     BottomLeft = '╰',
     BottomRight = '╯',
     Door = '=',
+    SlowTile = ':',
 }
 
 public static class ElementExtensions
@@ -30,4 +31,5 @@ public static class ElementExtensions
     public static bool IsWall(this Element element) => element is Element.Vertical or Element.Horizontal or Element.TopLeft or Element.TopRight or Element.BottomLeft or Element.BottomRight or Element.Corner or Element.Door;
     public static bool IsDot(this Element element) => element is Element.Dot;
     public static bool IsPowerPill(this Element element) => element is Element.PowerPill;
+    public static bool IsSlowTile(this Element element) => element is Element.SlowTile;
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Dunce Cap: Power Down
 What should Dots / Power Pills be?
 What should Enemies be?
 
+Iconic hats: https://screenrant.com/most-iconic-movie-hats/
+
 # We "Fixed" Cap Man to flip rather than rotate
 
 We voted on it! https://clips.twitch.tv/InexpensiveFitPrariedogShazBotstix-f3rtsBDRI1KQ0UOX


### PR DESCRIPTION
Adds and closes #15 .

Added a SlowTile to the Elements for board creation. EnemyActors by default will have a speed modifier of 75% when traversing SlowTiles.